### PR TITLE
[#45] add input validation to check for multi-word aspect and add mes…

### DIFF
--- a/ui/src/demos/sg-nlp/aspect-based-sentiment-analysis/config.tsx
+++ b/ui/src/demos/sg-nlp/aspect-based-sentiment-analysis/config.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import { DemoConfig } from "../../demos";
 import { ModelConfig } from "../../models";
 
@@ -18,11 +19,15 @@ const config: DemoConfig = {
   taskId: "aspect-based-sentiment-analysis",
   title: "Aspect-Based Sentiment Analysis",
   desc:
-    "Aspect-based sentiment analysis aims to classify the sentiment polarities of aspects found within the text. " +
-    "An aspect is a term that is relevant for sentiment analysis, for example a product's attributes or feature. " +
-    "A typical use case for to use it to analyze product reviews to understand which specific features in a product " +
-    "bring about positive/negative feedback from the consumers." +
-    "There are also models that aim to perform the aspect extraction and sentiment analysis in an end-to-end fashion.",
+    <div>
+      Aspect-based sentiment analysis aims to classify the sentiment polarities of aspects found within the text.
+      An aspect is a term that is relevant for sentiment analysis, for example a product's attributes or feature.
+      A typical use case for to use it to analyze product reviews to understand which specific features in a product
+      bring about positive/negative feedback from the consumers.
+      There are also models that aim to perform the aspect extraction and sentiment analysis in an end-to-end fashion.<br></br>
+      For demonstration purposes, this demo only support single word aspect.
+      Using the model from the python package allows multiple-word aspects.,
+    </div>,
   models: models,
 };
 

--- a/ui/src/demos/sg-nlp/aspect-based-sentiment-analysis/input.tsx
+++ b/ui/src/demos/sg-nlp/aspect-based-sentiment-analysis/input.tsx
@@ -21,6 +21,14 @@ export const validateInputs = (inputFields: Record<string, any>) => {
   const aspects = inputFields["aspects"];
   const sentence = inputFields["sentence"];
 
+  aspects.map((aspect: string) => {
+    if (aspect.split(" ").length > 1) {
+      errors["aspects"] =
+        "Currently this demo only supports single-word aspects. " +
+        "<br>Using the model from the python package allows multiple-word aspects.";
+    }
+  })
+
   const missingAspects = aspects
     .map((aspect: string) => {
       if (!sentence.includes(aspect)) {


### PR DESCRIPTION
- Add input validation for aspect token to check for multi-word aspect
- Add a message to indicate demo only supports single-word aspect and to refer to the python package for multi-word aspect